### PR TITLE
chore: delete dead code — unused exports, types, commented blocks

### DIFF
--- a/src/api/local.ts
+++ b/src/api/local.ts
@@ -2,7 +2,6 @@ import { fetch as httpfetch } from "@tauri-apps/plugin-http";
 import type {
   EntitlementsTokenResponse,
   FriendsResponse,
-  HelpResponse,
   Lockfile,
   PlayerAccount,
   PresenceResponse,
@@ -40,11 +39,7 @@ export class LocalAPI {
     return this.fetch("/player-account/aliases/v1/active");
   }
 
-  async help(): Promise<HelpResponse> {
-    return this.fetch("/help");
-  }
-
-  async getFriends(): Promise<FriendsResponse> {
+   async getFriends(): Promise<FriendsResponse> {
     return this.fetch("/chat/v4/friends");
   }
 

--- a/src/pages/Init.page.tsx
+++ b/src/pages/Init.page.tsx
@@ -26,9 +26,6 @@ export const InitPage = ({ status, error }: { status: string; error: string | nu
 				</button>
 			</section>
 
-			{/* <section className="flex flex-row space-x-4">
-        <a className="btn btn-sm btn-soft" href="https://www.facebook.com/aiocean.io/" target='_blank'><Github size={16} />GitHub</a>
-      </section> */}
 		</div>
 	);
 };

--- a/src/pages/Match.page.tsx
+++ b/src/pages/Match.page.tsx
@@ -208,28 +208,6 @@ export const MatchPage = () => {
 				</table>
 			</section>
 
-			{/* Round Timeline */}
-			{/* <section>
-      <ul className="timeline">
-        {
-          match.roundResults?.map(round => (
-             <li key={round.roundNum}>
-                <div className={clsx('timeline-box', round.winningTeam === 'Red' ? 'timeline-start bg-error/5' : 'timeline-end bg-info/10')}>{}</div>
-                <div className="timeline-middle bg-base-300 rounded-full p-2">
-                  {
-                    round.roundResultCode === 'Defuse' ? <ScissorsLineDashed size={20} />
-                    : round.roundResultCode === 'Elimination' ? <Skull size={20} />
-                    : round.roundResultCode === 'Detonate' ? <Bomb size={20} />
-                    : round.roundResultCode === 'Surrendered' ? <FlagOff size={20} />
-                    : null
-                  }
-                </div>
-                <hr />
-            </li>
-          ))
-        }
-      </ul>
-    </section> */}
 		</div>
 	);
 };

--- a/src/utils/platformReader.ts
+++ b/src/utils/platformReader.ts
@@ -1,9 +1,8 @@
 import { localDataDir } from "@tauri-apps/api/path";
-import { readDir, readTextFile, readTextFileLines } from "@tauri-apps/plugin-fs";
+import { readTextFile, readTextFileLines } from "@tauri-apps/plugin-fs";
 import base64 from "base-64";
 
 import lockfile from "@/../lockfile.json";
-import configs from "@/../tests/fixtures/local/configs.json";
 import ShooterGameLog from "@/../tests/fixtures/ShooterGame.json";
 
 import { isMac } from "./isMac";
@@ -15,16 +14,6 @@ const readLockfile = async (): Promise<string> => {
 		const path = await localDataDir();
 		const file = await readTextFile(`${path}\\Riot Games\\Riot Client\\Config\\lockfile`);
 		return file.toString();
-	}
-};
-
-const readConfigs = async (): Promise<string[]> => {
-	if (isMac()) {
-		return configs;
-	} else {
-		const path = await localDataDir();
-		const files = await readDir(`${path}\\Valorant\\Saved\\Config`);
-		return files.map((file) => file.name).filter((name) => name.match(/(.*)-(.*)-(.*)-(.*)-(.*)/));
 	}
 };
 
@@ -62,4 +51,4 @@ const parseLockFile = (content: string): { port: string; password: string } => {
 	return { port, password: base64.encode(`riot:${password}`) };
 };
 
-export { parseLockFile, parseShardFromLogline, readConfigs, readLockfile, readLog };
+export { parseLockFile, parseShardFromLogline, readLockfile, readLog };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,8 +2,6 @@ import base64 from "base-64";
 import { Buffer } from "buffer";
 import pako from "pako";
 
-const sleep = (ms: number = 2000) => new Promise((resolve) => setTimeout(resolve, ms));
-
 const base64Decode = (input: string): string => {
 	return base64.decode(input);
 };
@@ -22,4 +20,4 @@ const randomInt = (min: number, max: number): number => {
 	return Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled);
 };
 
-export { base64Decode, randomInt, sleep, zdecode, zencode };
+export { base64Decode, randomInt, zdecode, zencode };


### PR DESCRIPTION
## Summary
Resolves #66

## Root Cause
Codebase accumulated unused exports and commented-out UI blocks over time. No lint rule catches unused exports.

## Changes
- **Removed** `sleep()` from `utils/utils.ts` — never imported
- **Removed** `readConfigs()` from `utils/platformReader.ts` — never imported
- **Removed** `help()` method from `api/local.ts` — never called
- **Removed** commented-out Round Timeline section from `Match.page.tsx`
- **Removed** commented-out GitHub link from `Init.page.tsx`

## Tests
- Build passes cleanly
- 36 pass, 6 fail (pre-existing failures unrelated to this change)